### PR TITLE
Move definition of File#exists? out of File#store.

### DIFF
--- a/lib/carrierwave/storage/postgresql_table.rb
+++ b/lib/carrierwave/storage/postgresql_table.rb
@@ -171,10 +171,10 @@ module CarrierWave
               retry
             end
           end
+        end
 
-          def exists?
-            @record && @record.persisted?
-          end
+        def exists?
+          @record && @record.persisted?
         end
 
         def move_to(new_path)


### PR DESCRIPTION
File#exists? is defined inside of File#store. The tests pass because File#store is called in earlier tests, which defines the method for all following tests.

Problem becomes visible by running the 404 test only:
`bundle exec ruby -I"lib:test" test/rack_app_test.rb -n "test_not_found"`